### PR TITLE
Move to UserLoggedInEvent for login checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Move to UserLoggedInEvent for login checks, enabling compatibility with SAML login [#42](https://github.com/stjosh/auto_groups/issues/42)
 
 ## 1.1.1 - 2020-05-08
 ### Changed

--- a/lib/AutoGroupsManager.php
+++ b/lib/AutoGroupsManager.php
@@ -26,7 +26,7 @@
 namespace OCA\AutoGroups;
 
 use OCP\User\Events\UserCreatedEvent;
-use OCP\User\Events\PostLoginEvent;
+use OCP\User\Events\UserLoggedInEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\Group\Events\BeforeGroupDeletedEvent;
@@ -69,7 +69,7 @@ class AutoGroupsManager
 
         // If login hook is enabled, add user to / remove user from auto groups on every successful login
         if (filter_var($loginHook, FILTER_VALIDATE_BOOLEAN)) {
-            $eventDispatcher->addListener(PostLoginEvent::class, $groupAssignmentCallback);
+            $eventDispatcher->addListener(UserLoggedInEvent::class, $groupAssignmentCallback);
         }
 
         // Handle group deletion events

--- a/tests/Unit/AutoGroupsManagerTest.php
+++ b/tests/Unit/AutoGroupsManagerTest.php
@@ -25,7 +25,7 @@
 namespace OCA\AutoGroups\Tests\Unit;
 
 use OCP\User\Events\UserCreatedEvent;
-use OCP\User\Events\PostLoginEvent;
+use OCP\User\Events\UserLoggedInEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\Group\Events\BeforeGroupDeletedEvent;
@@ -121,7 +121,7 @@ class AutoGroupsManagerTest extends TestCase
                 [UserCreatedEvent::class, $this->callback('is_callable')],
                 [UserAddedEvent::class, $this->callback('is_callable')],
                 [UserRemovedEvent::class, $this->callback('is_callable')],
-                [PostLoginEvent::class, $this->callback('is_callable')],
+                [UserLoggedInEvent::class, $this->callback('is_callable')],
                 [BeforeGroupDeletedEvent::class, $this->callback('is_callable')]
             );
 


### PR DESCRIPTION
This fixes compatibility with alternative login flows, e.g., SAML login. Fixes #42 