### PR TITLE
Added UserFirstTimeLoggedInEvent

### DIFF
--- a/lib/AutoGroupsManager.php
+++ b/lib/AutoGroupsManager.php
@@ -26,7 +26,7 @@
 namespace OCA\AutoGroups;
 
 use OCP\User\Events\UserCreatedEvent;
-use OCP\User\Events\PostLoginEvent;
+use OCP\User\Events\UserLoggedInEvent;
 use OCP\User\Events\UserFirstTimeLoggedInEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
@@ -86,7 +86,7 @@ class AutoGroupsManager
 
         // If login hook is enabled, add user to / remove user from auto groups on every successful login
          if (filter_var($loginHook, FILTER_VALIDATE_BOOLEAN)) {
-            $eventDispatcher->addListener(PostLoginEvent::class, $groupAssignmentCallback);
+            $eventDispatcher->addListener(UserLoggedInEvent::class, $groupAssignmentCallback);
         }
 
         // Handle group deletion events

--- a/lib/AutoGroupsManager.php
+++ b/lib/AutoGroupsManager.php
@@ -27,6 +27,7 @@ namespace OCA\AutoGroups;
 
 use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\PostLoginEvent;
+use OCP\User\Events\UserFirstTimeLoggedInEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\Group\Events\BeforeGroupDeletedEvent;
@@ -74,6 +75,7 @@ class AutoGroupsManager
         // If creation hook is enabled, add user to / remove user from auto groups on creation
         if (filter_var($creationHook, FILTER_VALIDATE_BOOLEAN)) {
             $eventDispatcher->addListener(UserCreatedEvent::class, $groupAssignmentCallback);
+            $eventDispatcher->addListener(UserFirstTimeLoggedInEvent::class, $groupAssignmentCallback);
         }
 
         // If modification hook is enabled, add user to / remove user from auto groups on every modification of user groups


### PR DESCRIPTION
As mentioned in #74 I still think this is mainly an issue of `user_saml` not properly dispatching the correct events in case of user logins and user creation. But before making a PR and Issue over there, I want to get a better understanding of SAML and how that addon works. For the time being this would be at least a workaround for the "user creation" hook.