### PR TITLE
fix: pass string values for checkbox settings to fix 400 error

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -60,15 +60,15 @@ $(document).ready(function () {
     })
 
     $creationHook.change(function (ev) {
-      OCP.AppConfig.setValue('auto_groups', 'creation_hook', this.checked)
+      OCP.AppConfig.setValue('auto_groups', 'creation_hook', this.checked ? 'true' : 'false')
     })
 
     $modificationHook.change(function (ev) {
-      OCP.AppConfig.setValue('auto_groups', 'modification_hook', this.checked)
+      OCP.AppConfig.setValue('auto_groups', 'modification_hook', this.checked ? 'true' : 'false')
     })
 
     $loginHook.change(function (ev) {
-      OCP.AppConfig.setValue('auto_groups', 'login_hook', this.checked)
+      OCP.AppConfig.setValue('auto_groups', 'login_hook', this.checked ? 'true' : 'false')
     })
   }, 0)
 })


### PR DESCRIPTION
OCP.AppConfig.setValue was called with JavaScript booleans (true/false) for the hook checkboxes, but the Nextcloud provisioning API expects string values. The PHP backend also reads these as strings ('true'/'false'). This caused a 400 Bad Request on every checkbox toggle on Auto Groups 1.7.0.