### PR TITLE
perf: use getUserGroupIds

### DIFF
--- a/lib/AutoGroupsManager.php
+++ b/lib/AutoGroupsManager.php
@@ -100,7 +100,7 @@ class AutoGroupsManager
 
         // Get user information
         $user = $event->getUser();
-        $userGroupNames = array_keys($this->groupManager->getUserGroups($user));
+        $userGroupNames = $this->groupManager->getUserGroupIds($user);
 
         // Notice message for Auto Group Hook Execution
         $this->logger->debug('AutoGroups hook triggered for user ' . $user->getDisplayName());

--- a/tests/Unit/AutoGroupsManagerTest.php
+++ b/tests/Unit/AutoGroupsManagerTest.php
@@ -114,7 +114,7 @@ class AutoGroupsManagerTest extends TestCase
 
         // User belongs to no groups, so they should be added to the auto group
         $this->groupManager->expects($this->once())
-            ->method('getUserGroups')
+            ->method('getUserGroupIds')
             ->with($this->testUser)
             ->willReturn([]);
 
@@ -141,9 +141,9 @@ class AutoGroupsManagerTest extends TestCase
 
         // User is already in the auto group, so addUser should never be called
         $this->groupManager->expects($this->once())
-            ->method('getUserGroups')
+            ->method('getUserGroupIds')
             ->with($this->testUser)
-            ->willReturn(['autogroup' => []]);
+            ->willReturn(['autogroup']);
 
         $autogroup = $this->createMock(IGroup::class);
         $autogroup->expects($this->once())->method('getGID')->willReturn('autogroup');
@@ -168,9 +168,9 @@ class AutoGroupsManagerTest extends TestCase
 
         // User belongs to an override group, so they should be removed from all auto groups
         $this->groupManager->expects($this->once())
-            ->method('getUserGroups')
+            ->method('getUserGroupIds')
             ->with($this->testUser)
-            ->willReturn(['autogroup1' => [], 'overridegroup1' => [], 'autogroup2' => []]);
+            ->willReturn(['autogroup1', 'overridegroup1', 'autogroup2']);
 
         $groupMock = $this->createMock(IGroup::class);
         $groupMock->expects($this->exactly(2))->method('getGID')->willReturnOnConsecutiveCalls('autogroup1', 'autogroup2');
@@ -195,9 +195,9 @@ class AutoGroupsManagerTest extends TestCase
 
         // User is in an override group but not in any auto group, so removeUser should never be called
         $this->groupManager->expects($this->once())
-            ->method('getUserGroups')
+            ->method('getUserGroupIds')
             ->with($this->testUser)
-            ->willReturn(['overridegroup1' => []]);
+            ->willReturn(['overridegroup1']);
 
         $groupMock = $this->createMock(IGroup::class);
         $groupMock->expects($this->exactly(2))->method('getGID')->willReturnOnConsecutiveCalls('autogroup1', 'autogroup2');


### PR DESCRIPTION
Several time faster than getUserGroups as we don't have to load group objects.